### PR TITLE
Don't include incoming querystring in Dropbox Business callback_url

### DIFF
--- a/lib/omniauth/strategies/dropbox_oauth2.rb
+++ b/lib/omniauth/strategies/dropbox_oauth2.rb
@@ -44,7 +44,13 @@ module OmniAuth
         if @authorization_code_from_signed_request
           ''
         else
-          options[:callback_url] || super
+          # Override to remove query_string. Dropbox will verify that the
+          # redirect_uri provided in the token request matches the one used for
+          # the authorize request, and using the query string will cause
+          # redirect_uri mismatch errors.
+          # OmniAuth issue: https://github.com/omniauth/omniauth-oauth2/issues/93
+          # Similar: https://github.com/icoretech/omniauth-dropbox2/pull/2/files
+          full_host + script_name + callback_path
         end
       end
     end


### PR DESCRIPTION
Unlike most providers, the Dropbox Business (and Dropbox consumer) API
require the callback_url to exactly match what is configured in their
web UI, **including any querystring values**. By default, OmniAuth appends any
incoming querystrings to the callback_url being sent the the
provider.

This means that if your app begins auths with something like:
/auth/dropbox_oauth2?auth_version=v2,

Your callback_url becomes:
/auth/dropbox_oauth2/callback?auth_version=v2

This doesn't exact match Dropbox Business' overly strict requirements
for this URL:
/auth/dropbox_oauth2/callback

The fix is for this provider to override callback_url so that the
querystring is not appended automatically.

There is a long-going disucssion to see whether this should be fixed
in omniauth-oauth2 or within each affected provider strategy:
https://github.com/omniauth/omniauth-oauth2/issues/93

It's not super clear, but the consensus seems to be that this behavior
should be accounted for in the strategy.

Here's the similar issue for Dropbox (consumer):
https://github.com/icoretech/omniauth-dropbox2/pull/2

Unmerged PR in the consumer library:
https://github.com/icoretech/omniauth-dropbox2/pull/2